### PR TITLE
Fix - Use CRLF Instead of LF for Line Breaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,4 @@ tab_width = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = lf
+end_of_line = crlf

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,5 +7,5 @@ module.exports = {
   tabWidth: 2,
   trailingComma: 'all',
   arrowParens: 'always',
-  endOfLine: 'lf',
+  endOfLine: 'crlf',
 }


### PR DESCRIPTION
Use CRLF in .editorconfig and .prettierrc.js files